### PR TITLE
Fix joblib crash that always happens after ~8000 advection iterations

### DIFF
--- a/particle_advecter.py
+++ b/particle_advecter.py
@@ -107,6 +107,7 @@ class ParticleAdvecter:
 
         assert output_chunk_iters >= 1
 
+        self.iteration = 0
         self.particle_lons = particle_lons
         self.particle_lats = particle_lats
         self.velocity_field = velocity_field
@@ -127,6 +128,9 @@ class ParticleAdvecter:
             joblib.Parallel(n_jobs=self.N_procs)(
                 joblib.delayed(self.time_step_tile)(tile_id, start_time, end_time, dt) for tile_id in range(self.N_procs)
             )
+
+        iters = (end_time - start_time) // dt
+        self.iteration += iters
 
     def time_step_tile(self, tile_id, start_time, end_time, dt):
         tilestamp = "[Tile {:02d}]".format(tile_id) if self.N_procs > 1 else ""
@@ -166,7 +170,7 @@ class ParticleAdvecter:
                                              lon=particle_lons, lat=particle_lats)
 
         t = start_time
-        iteration = 0
+        iteration = self.iteration
         while t < end_time:
             iters_remaining = (end_time - t) // dt
             iters_to_do = min(self.output_chunk_iters, iters_remaining)

--- a/particle_advecter.py
+++ b/particle_advecter.py
@@ -156,8 +156,7 @@ class ParticleAdvecter:
         grid_times = np.array([(grid_times[i] - grid_times[0]) // np.timedelta64(1, "s")
                                for i in range(grid_times.size)])
 
-        logger.info("{:s} Building parcels grid, fields, and particle set... "
-                    "(this might take a long time as tons of data is downloaded over OPeNDAP)".format(tilestamp))
+        logger.info("{:s} Building parcels grid, fields, and particle set...".format(tilestamp))
 
         grid = parcels.grid.RectilinearZGrid(grid_lons, grid_lats, depth=grid_depth, time=grid_times, mesh="spherical")
 
@@ -244,6 +243,11 @@ class ParticleAdvecter:
                         .format(tilestamp, pretty_time(pickling_time), pretty_filesize(pickle_filesize),
                                 pretty_filesize(pickle_filesize / (iters_to_do * particles_per_tile))))
 
+        logger.info("{:s} Saving particle locations...".format(tilestamp))
+        for i, p in enumerate(pset):
+            self.particle_lons[tile_id][i] = p.lon
+            self.particle_lats[tile_id][i] = p.lat
+
     def create_netcdf_file(self, start_time, end_time, dt):
         logger = logging.getLogger(__name__ + "netcdf")
 
@@ -268,7 +272,7 @@ class ParticleAdvecter:
         pkl_files.sort()
 
         for pkl_filepath in pkl_files:
-            logger.info("Collecting particle location from {:s}...".format(pkl_filepath))
+            logger.info("Collecting particle locations from {:s}...".format(pkl_filepath))
 
             filename = os.path.basename(pkl_filepath)
             t1 = int(filename.split("_")[2])  # Starting iteration

--- a/rock_paper_scissors_argparse.py
+++ b/rock_paper_scissors_argparse.py
@@ -35,6 +35,7 @@ pRS, pPR, pSP = p, p, p + a
 output_dir = os.path.join(base_dir, "N" + str(N) + "_Kh" + str(Kh) + "_p" + str(p) + "_a" + str(a))
 
 start_time = datetime(2018, 1, 1)
+mid_time = datetime(2018, 7, 1)
 end_time = datetime(2018, 12, 31)
 dt = timedelta(hours=1)
 
@@ -45,7 +46,8 @@ particle_lons, particle_lats = uniform_particle_locations(N_particles=N, lat_min
 pa = ParticleAdvecter(particle_lons, particle_lats, N_procs=25, velocity_field="OSCAR", output_dir=output_dir, Kh=Kh)
 
 # Advect the particles and save all the data to NetCDF.
-pa.time_step(start_time, end_time, dt)
+pa.time_step(start_time, mid_time, dt)
+pa.time_step(mid_time, end_time, dt)
 pa.create_netcdf_file(start_time, end_time, dt)
 
 # Create an interaction simulator that uses the rock-paper-scissors pair interaction.

--- a/rock_paper_scissors_argparse.py
+++ b/rock_paper_scissors_argparse.py
@@ -36,7 +36,7 @@ output_dir = os.path.join(base_dir, "N" + str(N) + "_Kh" + str(Kh) + "_p" + str(
 
 start_time = datetime(2018, 1, 1)
 mid_time = datetime(2018, 7, 1)
-end_time = datetime(2018, 12, 31)
+end_time = datetime(2019, 1, 1)
 dt = timedelta(hours=1)
 
 # Generate initial locations for each particle.


### PR DESCRIPTION
Seems like this was a long-standing problem. Simple solution is to just advect in smaller 6-month chunks.

Just have to make sure we keep track of iterations and intermediate files properly so that the final `particle_data.nc` file comes out correctly.